### PR TITLE
feat: Add Google Maps integration with user-configurable map preferences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ TELOXIDE_TOKEN=YOUR_BOT_TOKEN_HERE
 # Log Level (Optional, defaults to 'info')
 # Examples: error, warn, info, debug, trace
 RUST_LOG=info
+
+# Google Maps Static API Configuration (Optional)
+# Get your API key from: https://console.cloud.google.com/google/maps-apis
+# If not provided, the bot will work without map images but will only send text notifications
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,16 +1037,20 @@ name = "luzern-velox-vibebot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
  "dotenvy",
  "log",
  "pretty_env_logger",
+ "regex",
  "reqwest",
  "scraper",
  "serde",
  "serde_json",
  "teloxide",
+ "tempfile",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2340,6 +2344,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ anyhow = "1.0"
 reqwest = "0.12.23"
 scraper = "0.23.1"
 chrono = { version = "0.4", features = ["serde"] }
+bytes = "1.5"
+tempfile = "3.8"
+urlencoding = "2.1"
+regex = "1.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,12 @@ use std::io::ErrorKind;
 use std::sync::Arc;
 use std::time::Duration;
 use teloxide::error_handlers::LoggingErrorHandler;
-use teloxide::{dptree, prelude::*, types::Message, utils::command::BotCommands};
+use teloxide::{
+    dptree,
+    prelude::*,
+    types::{InputFile, Message},
+    utils::command::BotCommands,
+};
 use tokio::sync::RwLock;
 use tokio::time::interval;
 
@@ -23,6 +28,12 @@ const CAMERA_SELECTOR: &str = "#radarList li > a";
 const CHECK_INTERVAL_MINUTES: u64 = 30;
 const DOWNTIME_START_HOUR: u8 = 2;
 const DOWNTIME_END_HOUR: u8 = 7;
+
+// Google Maps Static API configuration
+const GOOGLE_MAPS_BASE_URL: &str = "https://maps.googleapis.com/maps/api/staticmap";
+const MAP_ZOOM_LEVEL: u8 = 15;
+const MAP_WIDTH: u16 = 400 * 2;
+const MAP_HEIGHT: u16 = 300 * 2;
 
 // Retry configuration for network operations
 const MAX_RETRY_ATTEMPTS: u32 = 3;
@@ -49,6 +60,8 @@ enum Command {
     Status,
     #[command(description = "Toggle notifications for checks with no updates.")]
     NotifyNoUpdates,
+    #[command(description = "Toggle inclusion of maps in camera notifications.")]
+    ToggleMaps,
 }
 
 // Command handler for /start
@@ -126,13 +139,13 @@ async fn current_list_command(
         "No known speed cameras currently listed.".to_string()
     } else {
         log::info!("Formatting {} cameras for response", cameras.len());
-        let mut sorted_cameras: Vec<String> = cameras.iter().cloned().collect();
-        sorted_cameras.sort_unstable();
+        let mut sorted_cameras: Vec<CameraData> = cameras.iter().cloned().collect();
+        sorted_cameras.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         format!(
             "Current known speed cameras:\n{}",
             sorted_cameras
                 .iter()
-                .map(|c| format!("- {c}"))
+                .map(|c| format!("- {}", c.name))
                 .collect::<Vec<_>>()
                 .join("\n")
         )
@@ -211,11 +224,13 @@ async fn help_command(
         /current\\_list \\- Show all known cameras\n\
         /manual\\_update \\- Force immediate check\n\
         /notify\\_no\\_updates \\- Toggle no\\-update notifications\n\
+        /toggle\\_maps \\- Toggle map images in notifications\n\
         /status \\- Show bot status\n\
         /help \\- Show this help message\n\n\
         *Features:*\n\
         • Automatic checks every {} minutes\n\
         • No automatic checks between {}:00\\-{}:00\n\
+        • Map images with location overview \\(when available\\)\n\
         • Data sourced from Luzern Police website\n\n\
         Questions? Contact @aleeraser",
         CHECK_INTERVAL_MINUTES,
@@ -234,10 +249,16 @@ async fn help_command(
 async fn manual_update_command(
     bot: Bot,
     msg: Message,
-    _state: Arc<AppState>,
+    state: Arc<AppState>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let chat_id = msg.chat.id.0;
     log::info!("Received /manual_update command from chat ID: {chat_id}");
+
+    // Get user preferences for maps
+    let subscribers = state.subscribers.read().await;
+    let user_prefs = subscribers.get(&chat_id).cloned().unwrap_or_default();
+    let include_maps = user_prefs.include_maps;
+    drop(subscribers);
 
     bot.send_message(msg.chat.id, "Starting manual camera check...")
         .await?;
@@ -261,8 +282,8 @@ async fn manual_update_command(
                 current_cameras.len()
             );
 
-            // For manual updates, we only check for new cameras but don't send automatic notifications
-            let new_cameras: Vec<String> = current_cameras
+            // For manual updates, we check for new cameras and send maps to the requesting user
+            let new_cameras: Vec<CameraData> = current_cameras
                 .difference(&known_cameras)
                 .cloned()
                 .collect();
@@ -276,23 +297,49 @@ async fn manual_update_command(
             let new_count = new_cameras.len();
             let total_count = current_cameras.len();
 
-            let summary = if new_count > 0 {
-                let mut message = format!(
-                    "✅ Manual check complete!\n� Found {} new cameras out of {} total:\n",
+            if new_count > 0 {
+                // Send header message
+                let header_message = format!(
+                    "Found {} new cameras out of {} total:",
                     new_count, total_count
                 );
-                for camera in &new_cameras {
-                    message.push_str(&format!("- {}\n", camera));
-                }
-                message
-            } else {
-                format!(
-                    "✅ Manual check complete!\nNo new cameras found ({} total cameras)",
-                    total_count
-                )
-            };
+                bot.send_message(msg.chat.id, header_message).await?;
 
-            bot.send_message(msg.chat.id, summary).await?;
+                // Get Google Maps API key from environment
+                let google_maps_api_key = std::env::var("GOOGLE_MAPS_API_KEY").ok();
+                if google_maps_api_key.is_none() {
+                    log::warn!("GOOGLE_MAPS_API_KEY not found in environment. Map images will not be included in manual update.");
+                }
+
+                // Send individual messages with maps for each new camera
+                for camera in &new_cameras {
+                    let camera_message = format!("📍 {}", camera.name);
+
+                    match send_message_with_map(
+                        &bot,
+                        msg.chat.id,
+                        &camera_message,
+                        camera,
+                        google_maps_api_key.as_deref(),
+                        include_maps,
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            log::debug!("Successfully sent camera map for: {}", camera);
+                        }
+                        Err(e) => {
+                            log::error!("Failed to send camera map for {}: {}", camera, e);
+                        }
+                    }
+
+                    // Small delay between messages to avoid rate limiting
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            } else {
+                let summary = format!("No new cameras found ({} total cameras)", total_count);
+                bot.send_message(msg.chat.id, summary).await?;
+            }
         }
         Err(e) => {
             log::error!("Failed to fetch cameras during manual update: {e}");
@@ -406,16 +453,100 @@ async fn notify_no_updates_command(
     Ok(())
 }
 
+// Command handler for /toggle_maps
+async fn toggle_maps_command(
+    bot: Bot,
+    msg: Message,
+    state: Arc<AppState>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chat_id = msg.chat.id.0;
+    log::info!("Received /toggle_maps command from chat ID: {chat_id}");
+
+    // Get current preference
+    let mut subscribers = state.subscribers.write().await;
+    let current_prefs = subscribers
+        .entry(chat_id)
+        .or_insert_with(SubscriberData::default);
+
+    // Toggle the preference
+    current_prefs.include_maps = !current_prefs.include_maps;
+    let new_setting = current_prefs.include_maps;
+
+    // Save preferences to file
+    let subscribers_copy = subscribers.clone();
+    drop(subscribers);
+
+    match save_subscribers(SUBSCRIBERS_FILE_PATH, &subscribers_copy) {
+        Ok(_) => log::info!("Successfully saved subscriber preferences after toggle"),
+        Err(e) => {
+            log::error!("Failed to save user preferences: {e}");
+        }
+    }
+
+    // Send confirmation message
+    let message = if new_setting {
+        "✅ Maps will now be included with camera notifications\\."
+    } else {
+        "❌ Maps will no longer be included with camera notifications\\. You'll receive text\\-only messages\\."
+    };
+
+    bot.send_message(msg.chat.id, message)
+        .parse_mode(teloxide::types::ParseMode::MarkdownV2)
+        .await?;
+
+    log::info!("User {chat_id} toggled include_maps to: {new_setting}");
+    Ok(())
+}
+
+// Camera data with coordinates
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct CameraData {
+    name: String,
+    latitude: f64,
+    longitude: f64,
+}
+
+impl std::fmt::Display for CameraData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl std::hash::Hash for CameraData {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        // Convert f64 to bits for hashing
+        self.latitude.to_bits().hash(state);
+        self.longitude.to_bits().hash(state);
+    }
+}
+
+impl Eq for CameraData {}
+
+impl Ord for CameraData {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for CameraData {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 // Subscriber data with preferences
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct SubscriberData {
     notify_no_updates: bool,
+    include_maps: bool,
 }
 
 impl Default for SubscriberData {
     fn default() -> Self {
         Self {
             notify_no_updates: false, // Default to not sending "no updates" notifications
+            include_maps: true,       // Default to including maps in notifications
         }
     }
 }
@@ -426,14 +557,35 @@ struct AppState {
 }
 
 // Load known cameras from JSON file
-fn load_known_cameras(path: &str) -> Result<HashSet<String>> {
+fn load_known_cameras(path: &str) -> Result<HashSet<CameraData>> {
     match fs::read_to_string(path) {
         Ok(content) => {
             if content.is_empty() {
                 Ok(HashSet::new())
             } else {
-                serde_json::from_str(&content)
-                    .with_context(|| format!("Failed to parse JSON from {path}"))
+                // Try to load new format first, fallback to old format for migration
+                if let Ok(camera_data) = serde_json::from_str::<HashSet<CameraData>>(&content) {
+                    Ok(camera_data)
+                } else {
+                    // Legacy format migration: convert old string-based data
+                    log::warn!(
+                        "Converting legacy camera data format to new coordinate-based format"
+                    );
+                    let old_cameras: HashSet<String> = serde_json::from_str(&content)
+                        .with_context(|| format!("Failed to parse JSON from {path}"))?;
+
+                    // Convert old format to new format (without coordinates for now)
+                    let new_cameras: HashSet<CameraData> = old_cameras
+                        .into_iter()
+                        .map(|name| CameraData {
+                            name,
+                            latitude: 0.0,  // Will be updated on next fetch
+                            longitude: 0.0, // Will be updated on next fetch
+                        })
+                        .collect();
+
+                    Ok(new_cameras)
+                }
             }
         }
         Err(e) if e.kind() == ErrorKind::NotFound => Ok(HashSet::new()),
@@ -455,6 +607,32 @@ fn load_subscribers(path: &str) -> Result<HashMap<i64, SubscriberData>> {
                     serde_json::from_str::<HashMap<i64, SubscriberData>>(&content)
                 {
                     return Ok(subscribers);
+                }
+
+                // Try to parse as intermediate format (map with old SubscriberData without include_maps)
+                #[derive(Deserialize)]
+                struct OldSubscriberData {
+                    notify_no_updates: bool,
+                }
+
+                if let Ok(old_map) =
+                    serde_json::from_str::<HashMap<i64, OldSubscriberData>>(&content)
+                {
+                    log::info!(
+                        "Migrating {} subscribers from intermediate format to new format",
+                        old_map.len()
+                    );
+                    let mut new_subscribers = HashMap::new();
+                    for (chat_id, old_data) in old_map {
+                        new_subscribers.insert(
+                            chat_id,
+                            SubscriberData {
+                                notify_no_updates: old_data.notify_no_updates,
+                                include_maps: true, // Default to including maps
+                            },
+                        );
+                    }
+                    return Ok(new_subscribers);
                 }
 
                 // Fall back to old format (array of IDs) and migrate
@@ -553,22 +731,93 @@ async fn send_message_with_retry_and_parse_mode(
 }
 
 // Save known cameras to JSON file
-fn save_known_cameras(path: &str, cameras: &HashSet<String>) -> Result<()> {
-    let mut sorted_cameras: Vec<String> = cameras.iter().cloned().collect();
-    sorted_cameras.sort_unstable();
+fn save_known_cameras(path: &str, cameras: &HashSet<CameraData>) -> Result<()> {
+    let mut sorted_cameras: Vec<CameraData> = cameras.iter().cloned().collect();
+    sorted_cameras.sort_by(|a, b| a.name.cmp(&b.name));
 
     let content = serde_json::to_string_pretty(&sorted_cameras)
         .with_context(|| "Failed to serialize camera list to JSON")?;
     fs::write(path, content).with_context(|| format!("Failed to write state file {path}"))
 }
 
+// Generate a map image URL using Google Maps Static API with coordinates
+fn generate_map_url_with_coordinates(camera: &CameraData, api_key: &str) -> String {
+    format!(
+        "{}?center={},{}&zoom={}&size={}x{}&maptype=roadmap&markers=color:red|label:C|{},{}&key={}",
+        GOOGLE_MAPS_BASE_URL,
+        camera.latitude,
+        camera.longitude,
+        MAP_ZOOM_LEVEL,
+        MAP_WIDTH,
+        MAP_HEIGHT,
+        camera.latitude,
+        camera.longitude,
+        api_key
+    )
+}
+
+// Download map image from Google Maps Static API using coordinates
+async fn download_map_image_with_coordinates(
+    camera: &CameraData,
+    api_key: &str,
+) -> Result<bytes::Bytes> {
+    let url = generate_map_url_with_coordinates(camera, api_key);
+
+    log::debug!("Downloading map image for {} from: {}", camera.name, url);
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(&url)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .with_context(|| "Failed to send request to Google Maps API")?;
+
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Google Maps API returned error status: {}",
+            response.status()
+        ));
+    }
+
+    let image_bytes = response
+        .bytes()
+        .await
+        .with_context(|| "Failed to download image bytes")?;
+
+    log::debug!(
+        "Downloaded {} bytes for map image for {}",
+        image_bytes.len(),
+        camera.name
+    );
+    Ok(image_bytes)
+}
+
+// Create a temporary file for the map image
+async fn create_temp_map_file(image_bytes: bytes::Bytes) -> Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+
+    let mut temp_file =
+        tempfile::NamedTempFile::new().with_context(|| "Failed to create temporary file")?;
+
+    temp_file
+        .write_all(&image_bytes)
+        .with_context(|| "Failed to write image data to temporary file")?;
+
+    temp_file
+        .flush()
+        .with_context(|| "Failed to flush temporary file")?;
+
+    Ok(temp_file)
+}
+
 // Fetch the webpage and parse out the current camera locations
-async fn fetch_and_parse_cameras() -> Result<HashSet<String>> {
+async fn fetch_and_parse_cameras() -> Result<HashSet<CameraData>> {
     fetch_and_parse_cameras_with_retry().await
 }
 
 // Fetch cameras with retry logic for network failures
-async fn fetch_and_parse_cameras_with_retry() -> Result<HashSet<String>> {
+async fn fetch_and_parse_cameras_with_retry() -> Result<HashSet<CameraData>> {
     let mut last_error = None;
 
     for attempt in 1..=MAX_RETRY_ATTEMPTS {
@@ -608,8 +857,8 @@ async fn fetch_and_parse_cameras_with_retry() -> Result<HashSet<String>> {
     Err(last_error.unwrap())
 }
 
-// Single attempt to fetch and parse cameras
-async fn fetch_cameras_once() -> Result<HashSet<String>> {
+// Single attempt to fetch and parse cameras with coordinates
+async fn fetch_cameras_once() -> Result<HashSet<CameraData>> {
     let response = reqwest::get(CAMERA_LIST_URL)
         .await
         .with_context(|| format!("Failed to send GET request to {}", CAMERA_LIST_URL))?;
@@ -634,11 +883,12 @@ async fn fetch_cameras_once() -> Result<HashSet<String>> {
     })?;
 
     log::debug!(
-        "Extracting current camera locations using selector '{}'...",
+        "Extracting current camera locations with coordinates using selector '{}'...",
         CAMERA_SELECTOR
     );
     let mut current_cameras = HashSet::new();
     let mut found_any_cameras = false;
+
     for element in document.select(&selector) {
         let text = element
             .text()
@@ -646,10 +896,44 @@ async fn fetch_cameras_once() -> Result<HashSet<String>> {
             .join(" ")
             .trim()
             .to_string();
+
         // Specific filter for the Luzern page: Exclude the "reset filter" link text
-        if !text.is_empty() && text != "Kantonsübersicht zurücksetzen" {
-            log::debug!("- Found: {}", text);
-            current_cameras.insert(text);
+        if text.is_empty() || text == "Kantonsübersicht zurücksetzen" {
+            continue;
+        }
+
+        // Extract coordinates from onclick attribute
+        if let Some(onclick) = element.value().attr("onclick") {
+            if let Some((lat, lng)) = extract_coordinates_from_onclick(onclick) {
+                let camera_data = CameraData {
+                    name: text.clone(),
+                    latitude: lat,
+                    longitude: lng,
+                };
+
+                log::debug!("- Found: {} at coordinates ({}, {})", text, lat, lng);
+                current_cameras.insert(camera_data);
+                found_any_cameras = true;
+            } else {
+                log::warn!("Could not extract coordinates from onclick for: {}", text);
+                // Still add camera without coordinates for compatibility
+                let camera_data = CameraData {
+                    name: text.clone(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                };
+                current_cameras.insert(camera_data);
+                found_any_cameras = true;
+            }
+        } else {
+            log::warn!("No onclick attribute found for camera: {}", text);
+            // Still add camera without coordinates for compatibility
+            let camera_data = CameraData {
+                name: text.clone(),
+                latitude: 0.0,
+                longitude: 0.0,
+            };
+            current_cameras.insert(camera_data);
             found_any_cameras = true;
         }
     }
@@ -663,12 +947,104 @@ async fn fetch_cameras_once() -> Result<HashSet<String>> {
     Ok(current_cameras)
 }
 
+// Extract latitude and longitude from onclick attribute
+// Expects format like: "map.flyTo([47.0357531942389, 8.16251290734679], 16,{animate: false})"
+fn extract_coordinates_from_onclick(onclick: &str) -> Option<(f64, f64)> {
+    use regex::Regex;
+
+    // Create regex to match coordinates in flyTo call
+    let re = Regex::new(r"map\.flyTo\(\[([0-9.-]+),\s*([0-9.-]+)\]").ok()?;
+
+    if let Some(captures) = re.captures(onclick) {
+        let lat_str = captures.get(1)?.as_str();
+        let lng_str = captures.get(2)?.as_str();
+
+        let lat: f64 = lat_str.parse().ok()?;
+        let lng: f64 = lng_str.parse().ok()?;
+
+        Some((lat, lng))
+    } else {
+        None
+    }
+}
+
+// Send message with map image for a speed camera location
+async fn send_message_with_map(
+    bot: &Bot,
+    chat_id: ChatId,
+    message_text: &str,
+    camera_data: &CameraData,
+    google_maps_api_key: Option<&str>,
+    include_maps: bool,
+) -> Result<()> {
+    match (google_maps_api_key, include_maps) {
+        (Some(api_key), true) => {
+            // Try to send with map image
+            match send_message_with_map_image(bot, chat_id, message_text, camera_data, api_key)
+                .await
+            {
+                Ok(_) => {
+                    log::debug!(
+                        "Successfully sent message with map to chat ID {}",
+                        chat_id.0
+                    );
+                    Ok(())
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to send message with map to {}: {}. Falling back to text-only.",
+                        chat_id.0,
+                        e
+                    );
+                    // Fall back to text-only message
+                    send_message_with_retry(bot, chat_id, message_text.to_string()).await
+                }
+            }
+        }
+        (None, _) | (_, false) => {
+            // Send text-only message if no API key is available or user doesn't want maps
+            send_message_with_retry(bot, chat_id, message_text.to_string()).await
+        }
+    }
+}
+
+// Send message with map image using Google Maps Static API
+async fn send_message_with_map_image(
+    bot: &Bot,
+    chat_id: ChatId,
+    message_text: &str,
+    camera_data: &CameraData,
+    api_key: &str,
+) -> Result<()> {
+    // Download map image
+    let image_bytes = download_map_image_with_coordinates(camera_data, api_key)
+        .await
+        .with_context(|| "Failed to download map image")?;
+
+    // Create temporary file
+    let temp_file = create_temp_map_file(image_bytes)
+        .await
+        .with_context(|| "Failed to create temporary file")?;
+
+    // Create InputFile from the temp file path
+    let input_file = InputFile::file(temp_file.path());
+
+    // Send photo with caption
+    bot.send_photo(chat_id, input_file)
+        .caption(message_text)
+        .await
+        .with_context(|| "Failed to send photo message")?;
+
+    log::debug!("Successfully sent photo message to chat ID {}", chat_id.0);
+    Ok(())
+}
+
 // Compare current cameras with known ones and send Telegram notification to all subscribers
 async fn compare_and_notify(
     bot: Bot,
     state: Arc<AppState>,
-    current_cameras: &HashSet<String>,
-    known_cameras: &HashSet<String>,
+    current_cameras: &HashSet<CameraData>,
+    known_cameras: &HashSet<CameraData>,
 ) -> Result<()> {
     log::info!(
         "Comparing current cameras ({}) with known cameras ({})",
@@ -734,10 +1110,13 @@ async fn compare_and_notify(
     } else {
         log::info!("New cameras detected:");
         new_cameras.sort_unstable();
-        let mut message_text = String::from("🚨 Neue Blitzerstandorte in Luzern:\n");
-        for camera in &new_cameras {
-            log::info!("- {}", camera);
-            message_text.push_str(&format!("- {}\n", camera));
+
+        // Get Google Maps API key from environment
+        let google_maps_api_key = std::env::var("GOOGLE_MAPS_API_KEY").ok();
+        if google_maps_api_key.is_none() {
+            log::warn!(
+                "GOOGLE_MAPS_API_KEY not found in environment. Map images will not be included."
+            );
         }
 
         // Get subscriber list (read lock)
@@ -748,27 +1127,60 @@ async fn compare_and_notify(
         }
 
         log::info!(
-            "Sending notification to {} subscribers...",
-            subscribers.len()
+            "Sending notification to {} subscribers for {} new cameras...",
+            subscribers.len(),
+            new_cameras.len()
         );
         let mut success_count = 0;
         let mut error_count = 0;
 
-        for (chat_id_val, _) in subscribers.iter() {
+        for (chat_id_val, subscriber_data) in subscribers.iter() {
             let chat_id = ChatId(*chat_id_val);
-            match send_message_with_retry(&bot, chat_id, message_text.clone()).await {
-                Ok(_) => {
-                    log::debug!("Successfully sent notification to chat ID {}", chat_id.0);
-                    success_count += 1;
+
+            // Send a header message first
+            let header_message = format!(
+                "🚨 {} neue Blitzerstandorte in Luzern entdeckt:",
+                new_cameras.len()
+            );
+            match send_message_with_retry(&bot, chat_id, header_message).await {
+                Ok(_) => log::debug!("Sent header message to chat ID {}", chat_id.0),
+                Err(e) => log::error!("Failed to send header message to {}: {}", chat_id.0, e),
+            }
+
+            // Send individual messages with maps for each camera
+            for camera in &new_cameras {
+                log::info!("Sending notification for camera: {}", camera.name);
+                let camera_message = format!("📍 {}", camera.name);
+
+                match send_message_with_map(
+                    &bot,
+                    chat_id,
+                    &camera_message,
+                    camera,
+                    google_maps_api_key.as_deref(),
+                    subscriber_data.include_maps,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        log::debug!(
+                            "Successfully sent camera notification to chat ID {}",
+                            chat_id.0
+                        );
+                        success_count += 1;
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Failed to send camera notification to {} after retries: {}",
+                            chat_id.0,
+                            e
+                        );
+                        error_count += 1;
+                    }
                 }
-                Err(e) => {
-                    log::error!(
-                        "Failed to send Telegram message to {} after retries: {}",
-                        chat_id.0,
-                        e
-                    );
-                    error_count += 1;
-                }
+
+                // Small delay between messages to avoid rate limiting
+                tokio::time::sleep(Duration::from_millis(500)).await;
             }
         }
 
@@ -783,8 +1195,8 @@ async fn compare_and_notify(
 
 // Update the state file if the current camera list differs from the known one
 fn update_state_file(
-    current_cameras: &HashSet<String>,
-    known_cameras: &HashSet<String>,
+    current_cameras: &HashSet<CameraData>,
+    known_cameras: &HashSet<CameraData>,
 ) -> Result<()> {
     if known_cameras != current_cameras {
         log::info!(
@@ -922,6 +1334,10 @@ async fn handle_commands(
         Command::NotifyNoUpdates => {
             log::debug!("Routing to notify_no_updates_command");
             notify_no_updates_command(bot, msg, state).await
+        }
+        Command::ToggleMaps => {
+            log::debug!("Routing to toggle_maps_command");
+            toggle_maps_command(bot, msg, state).await
         }
     }
 }


### PR DESCRIPTION
- Add static map images to speed camera notifications using Google Maps Static API
- Extract precise coordinates from camera URLs instead of geocoding location names
- Add /toggle_maps command for users to enable/disable map attachments
- Center maps on individual camera locations for optimal visibility
- Include backward-compatible migration for subscriber preferences
- Default to maps enabled for new users, preservable per-user setting